### PR TITLE
Add catalogo_vendedores app

### DIFF
--- a/catalogo_vendedores/migrations/0001_initial.py
+++ b/catalogo_vendedores/migrations/0001_initial.py
@@ -10,7 +10,7 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
-        ('store', '0011_product_size'),
+        ('store', '0009_product_material'),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]
 

--- a/ecommerce/settings.py
+++ b/ecommerce/settings.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = [
     'store',
     'carts',
     'orders',
+    'catalogo_vendedores',
     'django.contrib.sites',
 ]
 


### PR DESCRIPTION
## Summary
- include `catalogo_vendedores` in Django INSTALLED_APPS
- fix missing dependency for catalogo_vendedores initial migration

## Testing
- `python manage.py makemigrations catalogo_vendedores && python manage.py migrate` *(fails: connection to server at "localhost" (127.0.0.1) port 5432 refused)*

------
https://chatgpt.com/codex/tasks/task_e_6858b68af57c8328afdae43f10e40939