### PR TITLE
Fix product detail lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,22 @@ Bienvenido al repositorio oficial del sitio web de **Reina Moda y Accesorios**, 
 
 ## 📦 Despliegue
 
-Este proyecto está listo para subir a producción en Hostinger VPS o similar.  
+Este proyecto está listo para subir a producción en Hostinger VPS o similar.
 Se recomienda usar **Gunicorn + Nginx + PostgreSQL** y herramientas como **Certbot** para HTTPS.
+
+---
+
+### ✅ Probar API de detalle de productos
+
+1. Ejecutar el servidor local con `python manage.py runserver`.
+2. Crear un producto en el admin o vía fixtures.
+3. En otra terminal, hacer una petición:
+
+   ```bash
+   curl http://127.0.0.1:8000/catalogo_vendedores/api/cbv/productos/1/
+   ```
+
+   Debería devolver un JSON con los datos del producto con ID `1`.
 
 ---
 

--- a/catalogo_vendedores/api_views.py
+++ b/catalogo_vendedores/api_views.py
@@ -22,11 +22,10 @@ class ProductoListView(generics.ListAPIView):
         )
 
 
-# 📦 Detalle de un producto individual por su código único
+# 📦 Detalle de un producto individual por su ID
 class ProductoDetalleView(generics.RetrieveAPIView):
     queryset = Product.objects.all()
     serializer_class = ProductSerializer
-    lookup_field = 'codigo_unico'
 
 
 # 💰 Registro de una venta con validación de stock

--- a/catalogo_vendedores/tests.py
+++ b/catalogo_vendedores/tests.py
@@ -1,3 +1,26 @@
-from django.test import TestCase
+from django.urls import reverse
+from rest_framework.test import APIClient
+from django.test import TestCase, override_settings
+from category.models import Category
+from store.models import Product
 
-# Create your tests here.
+
+@override_settings(DATABASES={'default': {'ENGINE': 'django.db.backends.sqlite3', 'NAME': ':memory:'}})
+class ProductoDetalleAPITest(TestCase):
+    def setUp(self):
+        self.category = Category.objects.create(category_name="Test", slug="test")
+        self.product = Product.objects.create(
+            product_name="Test Product",
+            slug="test-product",
+            description="desc",
+            price=10,
+            stock=5,
+            category=self.category,
+        )
+        self.client = APIClient()
+
+    def test_detalle_producto_por_pk(self):
+        url = reverse("producto-detalle-cbv", kwargs={"pk": self.product.pk})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["id"], self.product.pk)

--- a/catalogo_vendedores/urls.py
+++ b/catalogo_vendedores/urls.py
@@ -11,5 +11,5 @@ urlpatterns = [
 
     # APIs con vistas basadas en clase
     path('api/cbv/productos/', api_views.ProductoListView.as_view(), name='producto-lista-cbv'),
-    path('api/cbv/productos/<str:codigo_unico>/', api_views.ProductoDetalleView.as_view(), name='producto-detalle-cbv'),
+    path('api/cbv/productos/<int:pk>/', api_views.ProductoDetalleView.as_view(), name='producto-detalle-cbv'),
 ]

--- a/ecommerce/settings.py
+++ b/ecommerce/settings.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = [
     'store',
     'carts',
     'orders',
+    'rest_framework',
     'django.contrib.sites',
 ]
 


### PR DESCRIPTION
## Summary
- ensure detail URL uses pk
- register Django REST framework
- test producto detail by pk
- document manual curl test for product detail

## Testing
- `python manage.py test catalogo_vendedores.tests.ProductoDetalleAPITest.test_detalle_producto_por_pk` *(fails: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_6858b68df0f08328bee9632d3b5df1d8